### PR TITLE
Barrier geometry

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,6 @@
 var scene = new THREE.Scene();
 var camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
-camera.position.z = 3;
+camera.position.z = 5;
 
 var renderer = new THREE.WebGLRenderer();
 renderer.setSize(window.innerWidth, window.innerHeight);
@@ -10,16 +10,16 @@ document.body.appendChild(renderer.domElement);
 const sceneObjects = [];
 sceneObjects.push(NewEnclosingCylinder());
 
-const barrier1 = NewBarrier(0, 2 * Math.PI * 3 / 6);
-barrier1.position.z = 1;
+const barrier1 = NewBarrier(1 / 2, 0);
+barrier1.position.z = 2;
 sceneObjects.push(barrier1);
 
-const barrier2 = NewBarrier(0, 2 * Math.PI * 4 / 6);
+const barrier2 = NewBarrier(1 / 3, Math.PI / 2);
 barrier2.position.z = 0;
 sceneObjects.push(barrier2);
 
-const barrier3 = NewBarrier(0, 2 * Math.PI * 5 / 6);
-barrier3.position.z = -1;
+const barrier3 = NewBarrier(1 / 6, Math.PI / 8);
+barrier3.position.z = -2;
 sceneObjects.push(barrier3);
 
 sceneObjects.forEach(obj => scene.add(obj));

--- a/js/objects.js
+++ b/js/objects.js
@@ -4,7 +4,7 @@ function NewEnclosingCylinder() {
     const geometry = new THREE.CylinderGeometry(
         CYLINDER_RADIUS, // radiusTop
         CYLINDER_RADIUS, // radiusBottom
-        8, // height
+        20, // height
         32, // radialSegments
         1, // heightSegments
         true // openEnded
@@ -12,18 +12,21 @@ function NewEnclosingCylinder() {
     const material = new THREE.MeshStandardMaterial({ color: 0xffffff, metalness: 0.8 });
     const cylinder = new THREE.Mesh(geometry, material);
     material.side = THREE.DoubleSide; // or FrontSide or BackSide
-    cylinder.rotation.y += Math.PI / 6;
     cylinder.rotation.x += Math.PI / 2;
     return cylinder;
 }
 
-function NewBarrier(thetaStart, thetaEnd) {
+function NewBarrier(
+    gapFraction, // the fraction of the disc that should be cut out to form the gap to fly through
+    gapPosition  // the angle (in radians) that the centerline of the gap should be at
+) {
     const barrierRadius = CYLINDER_RADIUS * 0.99;
-    const geometry = new THREE.CylinderGeometry(barrierRadius, barrierRadius, 2, 32, 1, false, thetaStart, thetaEnd);
+    const geometry = new THREE.CylinderGeometry(barrierRadius, barrierRadius, 2, 32, 1, false, 0, (1 - gapFraction) * 2 * Math.PI);
     const material = new THREE.MeshStandardMaterial({ color: 0xffffff, metalness: 0.5 });
     const cylinder = new THREE.Mesh(geometry, material);
     material.side = THREE.FrontSide;
-    cylinder.rotation.y += Math.PI / 6;
     cylinder.rotation.x += Math.PI / 2;
+    cylinder.rotation.y += gapFraction * Math.PI + Math.PI / 2 + gapPosition;
+    // cylinder.rotation.y += gapPosition - gapFraction * 2 * Math.PI;
     return cylinder;
 }


### PR DESCRIPTION
Uses THREE.CylinderGeometry to create discs with cutouts to use as barriers. For this to be viable as the barriers we still need to see if we can use a CanvasTexture for this.
https://threejs.org/docs/#api/en/textures/CanvasTexture

<img width="723" alt="Screen Shot 2019-05-07 at 3 03 06 PM" src="https://user-images.githubusercontent.com/4078549/57325965-5652ec80-70d9-11e9-8208-9b2a3aa5514a.png">
