### PR TITLE
use kaleidoscope texture for cylinder walls as well

### DIFF
--- a/js/kaleidoscope.js
+++ b/js/kaleidoscope.js
@@ -189,6 +189,8 @@ if (IS_KALEIDOSCOPE_SIM) {
 } else {
     animate = function () {
         ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.fillStyle = "#111";
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
         sim.drawShapes();
         sim.updatePositions();
     }

--- a/js/main.js
+++ b/js/main.js
@@ -8,7 +8,7 @@ document.body.appendChild(renderer.domElement);
 
 // set up objects in scene
 const sceneObjects = [];
-sceneObjects.push(NewEnclosingCylinder());
+sceneObjects.push(NewPieCylinder());
 
 const barriers = [];
 
@@ -36,14 +36,23 @@ player.position.z = 4;
 scene.add(player);
 
 // set up lights
-const pointLight = new THREE.PointLight(0xffffff, 1, 100);
-scene.add(pointLight);
-pointLight.position.set(4, 4, 4);
-const centerLight = new THREE.PointLight(0xffffff, 1, 100);
-scene.add(centerLight);
-centerLight.position.set(0, 0, -5);
-const ambient = new THREE.AmbientLight(0xffffff);
-scene.add(ambient);
+const lights = [];
+
+const cameraLight = new THREE.PointLight(0xffffff, 1, 100, 0);
+cameraLight.position.set(0, 0, 6);
+lights.push(cameraLight);
+
+const ambientLight = new THREE.AmbientLight(0xffffff, 0.3);
+lights.push(ambientLight);
+
+// const directionalLight = new THREE.DirectionalLight(0xffffff, 100);
+// directionalLight.position.set(0, 0, -6);
+// lights.push(directionalLight);
+// const centerLight = new THREE.PointLight(0xffffff, 0.3, 100);
+// centerLight.position.set(0, 0, 0);
+// lights.push(centerLight);
+
+lights.forEach(l => scene.add(l));
 
 // addKeyAction takes a {key, keyCode}, onDown function, and onUp function, 
 // and together with the later addEventListener calls, makes it so that
@@ -167,6 +176,6 @@ function mainAnimationLoop() {
 
     renderer.render(scene, camera);
     animate();
-    barriers.forEach(b => b.children.forEach(child => child.material.map.needsUpdate = true));
+    SingletonKaleidoscopeTexture.needsUpdate = true;
 }
 mainAnimationLoop();

--- a/js/objects.js
+++ b/js/objects.js
@@ -1,6 +1,52 @@
 const CYLINDER_RADIUS = 1;
 const CYLINDER_HEIGHT = 20;
 
+function NewPieCylinder() {
+    const group = new THREE.Group();
+    const sliceAngle = 2 * Math.PI / 12;
+    for (let i = 0; i < 12; ++i) {
+        const geometry = new THREE.CylinderGeometry(
+            CYLINDER_RADIUS, // radiusTop
+            CYLINDER_RADIUS, // radiusBottom
+            CYLINDER_HEIGHT, // height
+            32, // radialSegments
+            1, // heightSegments
+            true, // openEnded
+            0,
+            2 * Math.PI / 12,
+        );
+        const material = KaleidoscopeMaterial();
+        const cylinder = new THREE.Mesh(geometry, material);
+        material.side = THREE.BackSide; // DoubleSide, FrontSide or BackSide
+        cylinder.rotation.x += Math.PI / 2;
+        cylinder.rotation.y += sliceAngle * i;
+        group.add(cylinder);
+    }
+
+    // add wall lines
+    const numWallLines = 12;
+    const lineRadius = 0.01;
+    for (let i = 0; i < numWallLines; ++i) {
+        const lineGeo = new THREE.CylinderGeometry(
+            lineRadius,
+            lineRadius,
+            CYLINDER_HEIGHT,
+            8,
+            1,
+            true
+        );
+        const lineMat = new THREE.MeshStandardMaterial({ color: 0x222222, metalness: 1.0 });
+        lineMat.side = THREE.FrontSide;
+        const lineCylinder = new THREE.Mesh(lineGeo, lineMat);
+        lineCylinder.rotation.x += Math.PI / 2;
+        const theta = 2 * Math.PI * i / 12;
+        lineCylinder.position.x = 0.99 * CYLINDER_RADIUS * Math.cos(theta);
+        lineCylinder.position.y = 0.99 * CYLINDER_RADIUS * Math.sin(theta);
+        group.add(lineCylinder);
+    }
+    return group;
+}
+
 function NewEnclosingCylinder() {
     const geometry = new THREE.CylinderGeometry(
         CYLINDER_RADIUS, // radiusTop
@@ -10,9 +56,10 @@ function NewEnclosingCylinder() {
         1, // heightSegments
         true // openEnded
     );
-    const material = new THREE.MeshStandardMaterial({ color: 0xffffff, metalness: 0.8 });
+    const material = new THREE.MeshStandardMaterial({ color: 0xffffff, metalness: 0 });
     const cylinder = new THREE.Mesh(geometry, material);
-    material.side = THREE.DoubleSide; // or FrontSide or BackSide
+    material.side = THREE.BackSide; // DoubleSide, FrontSide or BackSide
+
     cylinder.rotation.x += Math.PI / 2;
     const group = new THREE.Group();
     group.add(cylinder);
@@ -65,13 +112,23 @@ const KaleidoscopeTexture = () => {
     );
     return texture;
 }
+const SingletonKaleidoscopeTexture = KaleidoscopeTexture();
 
 const KaleidoscopeMaterial = () => {
-    const mat = new THREE.MeshStandardMaterial({ color: 0xFFFFFF, metalness: 0.5, map: KaleidoscopeTexture() });
+    const mat = new THREE.MeshStandardMaterial({
+        color: 0xFFFFFF, metalness: 0.0, map: SingletonKaleidoscopeTexture,
+        //  transparent: true, opacity: 0.75
+    });
     return mat;
 }
 
-const SingletonMaterial = KaleidoscopeMaterial();
+const EnclosingKaleidoscopeMaterial = () => {
+    const mat = new THREE.MeshStandardMaterial({
+        color: 0xFFFFFF, metalness: 0.1, map: SingletonKaleidoscopeTexture,
+    });
+    return mat;
+}
+
 
 const TOTAL_NUM_SLICES = 12;
 const SLICE_ANGLE = 2 * Math.PI / TOTAL_NUM_SLICES;
@@ -83,13 +140,13 @@ function NewPieBarrier(
     numSlices, // how many 1/6-th slices are in the barrier
     gapPosition, // the angle (in radians) that the centerline of the gap in the barrier should be at
 ) {
-    const barrierRadius = CYLINDER_RADIUS * 0.99;
+    const barrierRadius = CYLINDER_RADIUS;
     const slices = [];
     const sliceAngle = 2 * Math.PI / TOTAL_NUM_SLICES;
 
     for (let i = 0; i < numSlices; ++i) {
         const geometry = new THREE.CylinderGeometry(barrierRadius, barrierRadius, 1, 32, 1, false, 0, sliceAngle);
-        const material = SingletonMaterial;
+        const material = KaleidoscopeMaterial();
         const cylinder = new THREE.Mesh(geometry, material);
 
         // this is where the kaleidoscope effect comes in!
@@ -110,7 +167,7 @@ function NewPieBarrier(
 
 function NewPlayer() {
     const geometry = new THREE.SphereGeometry(0.2, 12, 12);
-    const material = new THREE.MeshStandardMaterial({ color: 0xFF0000, metalness: 0.5 });
+    const material = new THREE.MeshStandardMaterial({ color: 0xFF0000, metalness: 0.33 });
     const player = new THREE.Mesh(geometry, material);
     return player;
 }


### PR DESCRIPTION
Making the cylinder walls _reflective_ of the kaleidoscope barriers is hard, but we can get kind of a similar effect by building the enclosing cylinder piecewise in the same way as the barriers were, and then using the same kaleidoscope texture. 
<img width="673" alt="Screen Shot 2019-05-08 at 12 05 29 PM" src="https://user-images.githubusercontent.com/4078549/57390162-b1441c80-7189-11e9-9bc3-430dfdcf3ddb.png">
