### PR TITLE
Low-hanging optimizations

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -153,6 +153,7 @@ addKeyAction(
 );
 
 pauseOrUnpause();
+renderer.render(scene, camera);
 
 document.addEventListener('keydown', (event) => {
     keyActions.forEach((action) => {
@@ -227,7 +228,6 @@ function mainAnimationLoop() {
     }
 
     if (isPaused) {
-        renderer.render(scene, camera);
         return;
     }
     // update from WASD movement
@@ -265,9 +265,6 @@ function mainAnimationLoop() {
         scene.add(newBarrier);
 
         // dispose of old barrier
-        barriers[0].children.forEach(child => {
-            child.material.dispose();
-        });
         scene.remove(barriers[0]);
         barriers.shift();
     }
@@ -282,10 +279,6 @@ function mainAnimationLoop() {
         newCylinder.rotateOnWorldAxis(Z_AXIS, WorldZRotation);
 
         // dispose of old cylinder
-        enclosingCylinders[0].children.forEach(child => {
-            child.material.dispose();
-            child.geometry.dispose();
-        });
         scene.remove(enclosingCylinders[0]);
         enclosingCylinders.shift();
     }

--- a/js/objects.js
+++ b/js/objects.js
@@ -1,21 +1,23 @@
 const CYLINDER_RADIUS = 1;
 const CYLINDER_HEIGHT = 20;
 
+const EnclosingCylinderGeometry = new THREE.CylinderGeometry(
+    CYLINDER_RADIUS, // radiusTop
+    CYLINDER_RADIUS, // radiusBottom
+    CYLINDER_HEIGHT, // height
+    32, // radialSegments
+    1, // heightSegments
+    true, // openEnded
+    0,
+    2 * Math.PI / 12,
+);
+
 function NewPieCylinder(startingZ, parity = false) {
     const group = new THREE.Group();
     const sliceAngle = 2 * Math.PI / 12;
     for (let i = 0; i < 12; ++i) {
-        const geometry = new THREE.CylinderGeometry(
-            CYLINDER_RADIUS, // radiusTop
-            CYLINDER_RADIUS, // radiusBottom
-            CYLINDER_HEIGHT, // height
-            32, // radialSegments
-            1, // heightSegments
-            true, // openEnded
-            0,
-            2 * Math.PI / 12,
-        );
-        const material = EnclosingKaleidoscopeMaterial();
+        const geometry = EnclosingCylinderGeometry;
+        const material = SingletonEnclosingKaleidoscopeMaterial;
         const cylinder = new THREE.Mesh(geometry, material);
         material.side = THREE.BackSide; // DoubleSide, FrontSide or BackSide
         cylinder.rotation.x += Math.PI / 2;
@@ -70,12 +72,16 @@ const KaleidoscopeMaterial = () => {
     return mat;
 }
 
+const SingletonKaleidoscopeMaterial = KaleidoscopeMaterial();
+
 const EnclosingKaleidoscopeMaterial = () => {
     const mat = new THREE.MeshStandardMaterial({
         color: 0x888888, metalness: 0.3, map: SingletonKaleidoscopeTexture,
     });
     return mat;
 }
+
+const SingletonEnclosingKaleidoscopeMaterial = EnclosingKaleidoscopeMaterial();
 
 const TOTAL_NUM_SLICES = 12;
 const SLICE_ANGLE = 2 * Math.PI / TOTAL_NUM_SLICES;


### PR DESCRIPTION
We skip rendering entirely if the game is paused, and we create only one instance of materials/geometries we use rather than creating and disposing new ones every time we create/destroy barriers and cylinders. 