### PR TITLE
Change jump behavior and fix losing screen bug

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -177,9 +177,6 @@ const practicemodetext = document.getElementById("practicemode");
 addKeyAction(
     KeyP,
     event => {
-        if (inLosingState) {
-            return;
-        }
         if (inPracticeMode) {
             practicemodetext.classList.remove("ispractice");
             speedmenu.classList.remove("ispractice");

--- a/js/physics.js
+++ b/js/physics.js
@@ -18,11 +18,11 @@ function touchingCylinder() {
 var jumped = false;
 function handleJump() {
     jumped = false;
-    if (currTouchingCylinder) {
-        velocity = new THREE.Vector3();
+    if (currTouchingCylinder && player.position.y < 0) {
+	velocity = new THREE.Vector3();
         let jumpForce = player.position.clone().negate().setLength(CYLINDER_RADIUS - PLAYER_RADIUS);
-        jumpForce.multiplyScalar(1.2);
-        netForces.copy(jumpForce);
+	jumpForce.multiplyScalar(1.2)
+        netForces.add(jumpForce);
     }
 }
 


### PR DESCRIPTION
- Prohibits jumps when player.position.y > 0. I noticed some people would hold the spacebar too long and the ball would keep bouncing quickly between the floor and the ceiling. This change brings it closer to the expected behavior and doesn't inhibit gameplay much (it's rare to need to jump from the ceiling).

- Fixed bug where you couldn't enter practice mode from the lose screen.

